### PR TITLE
feat: changed how block is mine: use padding instead of interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - replace sparse merkle tree with sorted merkle tree
 - sort leaves keys in merkle tree
 - use coders from `@umb-network/toolbox` in tests
+- changed how block is mine: use `blockPadding` instead of `interval`


### PR DESCRIPTION
Padding is used to enforce block mining frequency (same as interval was), but it is working as "minimal gap" between current and next block. That way:
- we not creating empty blocks as it was for interval - when padding pass nothing happens, we still at the same block height
- we can adjust padding in real time