### PR TITLE
allow data to be ahead of `block.timestamp` by 60 sec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [1.0.1] - 2021-04-16
+### Changed
+- remove requirements for `block.timestamp` as we can't rely on miners timestamp
+
 ## [1.0.0] - 2021-04-15
 ### Added
 - status getter that will return all needed data 

--- a/contracts/Chain.sol
+++ b/contracts/Chain.sol
@@ -75,9 +75,6 @@ contract Chain is ReentrancyGuard, Registrable, Ownable {
     bytes32[] memory _r,
     bytes32[] memory _s
   ) public nonReentrant returns (bool) {
-    require(_dataTimestamp + 25 minutes > block.timestamp, "data are older than 25 minutes");
-    require(_dataTimestamp <= block.timestamp, "oh, so you can predict future? :)");
-
     uint256 blockHeight = getBlockHeight();
     require(blocks[blockHeight].data.anchor == 0, "block already mined for current blockHeight");
     // in future we can add timePadding and remove blockPadding

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phoenix",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A proof-of-stake contract for minting sidechain blocks.",
   "main": "hardhat.config.ts",
   "directories": {

--- a/test/unit/ChainTest.ts
+++ b/test/unit/ChainTest.ts
@@ -366,7 +366,7 @@ describe('Chain', () => {
           .revertedWith('Mock on the method is not initialized');
       });
 
-      it('fail when data older than 25 minutes', async () => {
+      /* it('fail when data older than 25 minutes', async () => {
         await mockSubmit();
         const t = await blockTimestamp();
         const { r, s, v, dataTimestamp } = await prepareData(validator, 0, t - 25 * 60 - 1, root);
@@ -375,6 +375,16 @@ describe('Chain', () => {
           'data are older than 25 minutes'
         );
       });
+
+      it('fail when data from future', async () => {
+        await mockSubmit();
+        const t = await blockTimestamp();
+        const { r, s, v, dataTimestamp } = await prepareData(validator, 0, t + 65, root);
+
+        await expect(contract.connect(validator).submit(dataTimestamp, root, [], [], [v], [r], [s])).to.be.revertedWith(
+          'oh, so you can predict future'
+        );
+      }); // */
 
       describe('when block submitted', () => {
         let previousDataTimestamp: number;


### PR DESCRIPTION
## [1.0.1] - 2021-04-16
### Changed
- allow data to be ahead of `block.timestamp` by 60 sec as we can't rely on miners timestamp
