### PR TITLE
feat: separate FCD from Block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- use `uint32` for `dataTimestamp`
+- remove FCD from block and save only current values
 
 ## [1.0.3] - 2021-04-24
 ### Fixed

--- a/scripts/utils/helpers.ts
+++ b/scripts/utils/helpers.ts
@@ -47,7 +47,7 @@ export const pressToContinue = (charToPress = 'y', callback: () => void): void =
   console.log('-'.repeat(80));
 
   const stdin = process.stdin;
-  const {setRawMode} = stdin;
+  const { setRawMode } = stdin;
 
   if (setRawMode === undefined) {
     callback();


### PR DESCRIPTION
Our  self-adjusting consensus can drop keys, so for FCD we can  end up with "gaps" and it will be hard for developers to deal with FCD.

This PR solves  the issue:
1. we will store each FCD independently
2. there will be no gaps - it will always be last value easy accessible
3. we can  add or remove FCD any time and it will have no affect on "last value"
4. disadvantage is that we have to store `dataTimestamp` for each key, but I also optimised types so we using ~10% less gass

