### PR TITLE
fix: `getStatus` returns valid next `blockHeight`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [1.0.2] - 2021-04-19
+### Fixed
+- `getStatus` returns valid next `blockHeight`
+
 ## [1.0.1] - 2021-04-16
 ### Changed
 - remove requirements for `block.timestamp` as we can't rely on miners timestamp

--- a/contracts/Chain.sol
+++ b/contracts/Chain.sol
@@ -175,7 +175,7 @@ contract Chain is ReentrancyGuard, Registrable, Ownable {
       (, locations[i]) = vr.validators(validators[i]);
     }
 
-    nextLeader = numberOfValidators > 0 ? validators[getLeaderIndex(numberOfValidators, block.number + 1)] : address(0);
+    nextLeader = numberOfValidators > 0 ? validators[getLeaderIndex(numberOfValidators, blockNumber + 1)] : address(0);
 
     IStakingBank stakingBank = stakingBankContract();
     powers = new uint256[](numberOfValidators);
@@ -185,21 +185,23 @@ contract Chain is ReentrancyGuard, Registrable, Ownable {
       powers[i] = stakingBank.balanceOf(validators[i]);
     }
 
-    nextBlockHeight = getBlockHeight();
+    nextBlockHeight = getBlockHeightForBlock(blockNumber + 1);
   }
 
   function getBlockHeight() public view returns (uint256) {
+    return getBlockHeightForBlock(block.number);
+  }
+
+  function getBlockHeightForBlock(uint256 _ethBlockNumber) public view returns (uint256) {
     uint _blocksCount = blocksCount + blocksCountOffset;
 
     if (_blocksCount == 0) {
       return 0;
     }
 
-    if (blocks[_blocksCount - 1].data.anchor + blockPadding < block.number) {
-      return _blocksCount;
-    }
-
-    return _blocksCount - 1;
+    return (blocks[_blocksCount - 1].data.anchor + blockPadding < _ethBlockNumber)
+      ? _blocksCount
+      : _blocksCount - 1;
   }
 
   function getLatestBlockHeightWithData() public view returns (uint256) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phoenix",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A proof-of-stake contract for minting sidechain blocks.",
   "main": "hardhat.config.ts",
   "directories": {
@@ -30,7 +30,7 @@
     "lint": "npm run lint:ts && npm run lint:sol",
     "lint:ts": "eslint . --ext .ts,.tsx,.ts --max-warnings=6",
     "lint:fix": "npm run lint:ts -- --fix",
-    "lint:sol": "solhint \"contracts/**/*.sol\" --max-warnings=3",
+    "lint:sol": "solhint \"contracts/**/*.sol\" --max-warnings=2",
     "prettier": "prettier --config .prettierrc 'scripts/**/*.ts' 'test/**/*.ts' --check",
     "prettier:format": "prettier --config .prettierrc 'scripts/**/*.ts' 'test/**/*.ts' --write"
   },

--- a/test/unit/ChainTest.ts
+++ b/test/unit/ChainTest.ts
@@ -14,7 +14,7 @@ import ValidatorRegistry from '../../artifacts/contracts/ValidatorRegistry.sol/V
 import StakingBank from '../../artifacts/contracts/StakingBank.sol/StakingBank.json';
 import Token from '../../artifacts/contracts/Token.sol/Token.json';
 import { toBytes32 } from '../../scripts/utils/helpers';
-import { blockTimestamp, mintBlocks } from '../utils';
+import { blockNumber, blockTimestamp, mintBlocks } from '../utils';
 
 const { toWei } = hre.web3.utils;
 
@@ -552,6 +552,28 @@ describe('Chain', () => {
         });
       });
     });
+  });
+
+  it('expect to getBlockHeightForBlock()', async () => {
+    let bn = await blockNumber();
+    expect(await contract.getBlockHeightForBlock(bn)).to.eq(0);
+    expect(await contract.getBlockHeightForBlock(bn + 100)).to.eq(0);
+
+    await mockSubmit();
+    await executeSubmit(0, await blockTimestamp());
+    expect(await contract.getBlockHeightForBlock(bn)).to.eq(0);
+
+    await mintBlocks(blockPadding);
+    await mockSubmit();
+    await executeSubmit(1, await blockTimestamp());
+    bn = await blockNumber();
+
+    for (let i = 0; i <= blockPadding; i++) {
+      expect(await contract.getBlockHeightForBlock(bn + i)).to.eq(1);
+    }
+
+    expect(await contract.getBlockHeightForBlock(bn + blockPadding + 1)).to.eq(2);
+    expect(await contract.getBlockHeightForBlock(bn + blockPadding + 1000)).to.eq(2);
   });
 
   it('expect to getStatus()', async () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -10,3 +10,8 @@ export const blockTimestamp = async (): Promise<number> => {
   const block = await ethers.provider.getBlock('latest');
   return block.timestamp;
 };
+
+export const blockNumber = async (): Promise<number> => {
+  const block = await ethers.provider.getBlock('latest');
+  return block.number;
+};


### PR DESCRIPTION
## [1.0.2] - 2021-04-19
### Fixed
- `getStatus` returns valid next `blockHeight`