### PR TITLE
fix: ensure `getLeaderIndex` uses padding in right way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [1.0.3] - 2021-04-24
+### Fixed
+- ensure `getLeaderIndex` uses padding in right way
+
 ## [1.0.2] - 2021-04-19
 ### Fixed
 - `getStatus` returns valid next `blockHeight`

--- a/contracts/Chain.sol
+++ b/contracts/Chain.sol
@@ -211,8 +211,9 @@ contract Chain is ReentrancyGuard, Registrable, Ownable {
   function getLeaderIndex(uint256 numberOfValidators, uint256 ethBlockNumber) public view returns (uint256) {
     uint256 latestBlockHeight = getLatestBlockHeightWithData();
 
+    // blockPadding + 1 => because padding is a space between blocks, so next round starts on first block after padding
     uint256 validatorIndex = latestBlockHeight +
-      (ethBlockNumber - blocks[latestBlockHeight].data.anchor) / blockPadding;
+      (ethBlockNumber - blocks[latestBlockHeight].data.anchor) / (blockPadding + 1);
 
     return validatorIndex % numberOfValidators;
   }


### PR DESCRIPTION
## [1.0.3] - 2021-04-24
### Fixed
- ensure `getLeaderIndex` uses padding in right way