### PR TITLE
feat: save creation block number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [2.1.0] - 2021-06-01
+### Added
+- add block number when contract was created
+
 ## [2.0.0] - 2021-05-24
 
 ### Changed

--- a/contracts/Chain.sol
+++ b/contracts/Chain.sol
@@ -37,11 +37,13 @@ contract Chain is Registrable, Ownable {
 
   uint32 public blocksCount;
   uint32 public blocksCountOffset;
+  uint256 public creationBlock;
   uint16 public padding;
 
   // ========== CONSTRUCTOR ========== //
 
   constructor(address _contractRegistry, uint16 _padding) public Registrable(_contractRegistry) {
+    creationBlock = block.number;
     padding = _padding;
     Chain oldChain = Chain(Registry(_contractRegistry).getAddress("Chain"));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phoenix",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A proof-of-stake contract for minting sidechain blocks.",
   "main": "hardhat.config.ts",
   "directories": {

--- a/test/unit/ChainTest.ts
+++ b/test/unit/ChainTest.ts
@@ -132,6 +132,10 @@ describe('Chain', () => {
   });
 
   describe('when deployed', () => {
+    it('expect to have creationBlock', async () => {
+      expect(await contract.creationBlock()).to.gt(0);
+    });
+
     it('expect to have padding', async () => {
       expect(await contract.padding()).to.eq(timePadding);
     });


### PR DESCRIPTION
## [2.1.0] - 2021-06-01
### Added
- add block number when contract was created


I need this for Sanctuary, so I can finish ticket about getting consensus data from contract, not from validators.