### PR TITLE
chore: address audit suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - use `timestamp` as block ID
 - new multichain architecture
+- address Peckshield audit suggestions
 
 ## [4.6.2] - 2022-09-27
 ### Changed

--- a/contracts/BaseChain.sol
+++ b/contracts/BaseChain.sol
@@ -68,9 +68,8 @@ abstract contract BaseChain is Registrable, Ownable {
     error ArraysDataDoNotMatch();
     error AlreadyDeprecated();
     error AlreadyRegistered();
-    error BlockSubmittedToFast();
+    error BlockSubmittedToFastOrDataToOld();
     error ContractNotReady();
-    error DataToOld();
     error FCDOverflow();
     error InvalidContractType();
     error NoChangeToState();

--- a/contracts/Chain.sol
+++ b/contracts/Chain.sol
@@ -46,7 +46,9 @@ contract Chain is BaseChain {
         bytes32[] memory _r,
         bytes32[] memory _s
     ) external {
-        if (_keys.length != _values.length) revert ArraysDataDoNotMatch();
+        // below two checks are only for pretty errors, so we can safe gas and allow for raw revert
+        // if (_keys.length != _values.length) revert ArraysDataDoNotMatch();
+        // if (_v.length != _r.length || _r.length != _s.length) revert ArraysDataDoNotMatch();
 
         _verifySubmitTimestampAndIncSequence(_dataTimestamp);
 
@@ -87,10 +89,7 @@ contract Chain is BaseChain {
             prevSigner = signer;
 
             if (balance == 0) {
-                unchecked {
-                    i++;
-                }
-
+                unchecked { i++; }
                 continue;
             }
 
@@ -225,7 +224,7 @@ contract Chain is BaseChain {
         return stakingBank.addresses(validatorIndex);
     }
 
-    /// @dev we had stack too dip in `submit` so this method was created as a solution
+    /// @dev we had stack too deep in `submit` so this method was created as a solution
     // we increasing `_consensusData.sequence` here so we don't have to read sequence again in other place
     function _verifySubmitTimestampAndIncSequence(uint256 _dataTimestamp) internal {
         ConsensusData memory data = _consensusData;
@@ -236,10 +235,8 @@ contract Chain is BaseChain {
 
         unchecked {
             // we will not overflow with timestamp and padding in a life time
-            if (data.lastTimestamp + data.padding >= _dataTimestamp) revert BlockSubmittedToFast();
+            if (data.lastTimestamp + data.padding >= _dataTimestamp) revert BlockSubmittedToFastOrDataToOld();
         }
-
-        if (_dataTimestamp <= data.lastTimestamp) revert DataToOld();
 
         unchecked {
             // we will not overflow in a life time

--- a/contracts/StakingBank.sol
+++ b/contracts/StakingBank.sol
@@ -123,7 +123,7 @@ contract StakingBank is IStakingBank, ERC20, ReentrancyGuard, Registrable, Ownab
         uint256 balance = balanceOf(_id);
 
         if (balance != 0) {
-            _unstake(_id, balanceOf(_id));
+            _unstake(_id, balance);
         }
 
         if (addresses.length == 1) {


### PR DESCRIPTION
- `PVE001` - removed, this check would be only for pretty `DataToOld` error, we can leave just one check, no need to spend gas on it
- `PVE002-2` - I would use something like `if (_v.length != _r.length || _r.length != _s.length) revert ArraysDataDoNotMatch();` but it will increase gas, and this is only about pretty errors, so I removed it, I added tests to confirm it is working as expected, I also added comment
- `PVE003` - atm owner is single wallet (EOA), but once council decide, we can set multisig, nothing to do here in terms of coding, it will be matter of transfer ownership
- `N1`: improved, however we will not push this version to prod BSC because we can't replace this contract, so we will stay with current version
- `PVE002`: same as `PVE002-2`, added additional tests
